### PR TITLE
Clicks on LABEL's for radios and checkboxes weren't triggering, so I made some changes

### DIFF
--- a/pointer_events_polyfill.js
+++ b/pointer_events_polyfill.js
@@ -78,7 +78,7 @@
 
         // clicks on labels are special, resolve the INPUT tag it relates to if possible and make that the target
         if($target.prop("tagName") === "LABEL") {
-          if((idAttr = $target.attr("id"))) {
+          if((idAttr = $target.attr("for"))) {
             $target = $("#" + idAttr);
           } else {
             $nestedInput = $target.find("input");


### PR DESCRIPTION
Thanks for a nice polyfill, it gave me a lot to work with.

Not sure if you're interested in pull requests, but I made some changes to support clicks on LABEL tags associated with radios and checkboxes.  For whatever reason, real clicks on the label bubble to the associated radio, but simulated clicks did not.

Also, I wasn't too keen on reusing the Event e and just changing the target the way you were doing, so I went ahead and did a weak little clone and triggered that.
