### PR TITLE
Close last declaration

### DIFF
--- a/pointer_events_polyfill.js
+++ b/pointer_events_polyfill.js
@@ -38,7 +38,7 @@ PointerEventsPolyfill.initialize = function(options){
     if(PointerEventsPolyfill.singleton == null)
       PointerEventsPolyfill.singleton = new PointerEventsPolyfill(options);
     return PointerEventsPolyfill.singleton;
-}
+};
 
 // handle mouse events w/ support for pointer-events: none
 PointerEventsPolyfill.prototype.register_mouse_events = function(){
@@ -65,4 +65,4 @@ PointerEventsPolyfill.prototype.register_mouse_events = function(){
         }
         return true;
     });
-}
+};


### PR DESCRIPTION
Need to close the declaration to avoid errors in combined Js files.
//file1
var foo = function(bar) { console.log(bar) }
//file2
(function() { alert(1) })();
